### PR TITLE
使用新方式显示系统托盘

### DIFF
--- a/HideTaskbar/HideTaskbar.csproj
+++ b/HideTaskbar/HideTaskbar.csproj
@@ -12,7 +12,7 @@
     <SignAssembly>False</SignAssembly>
 
     <AssemblyTitle>隐藏工具栏小工具</AssemblyTitle>
-    <AssemblyVersion>1.3.1</AssemblyVersion>
+    <AssemblyVersion>1.4.0</AssemblyVersion>
     <StartupObject>HideTaskbar.Program</StartupObject>
     <Authors>LonelyAtom</Authors>
     <Title>$(AssemblyName)</Title>

--- a/HideTaskbar/MainForm.cs
+++ b/HideTaskbar/MainForm.cs
@@ -136,6 +136,10 @@ namespace HideTaskbar
         // 隐藏/显示任务栏
         private void HideOrShowTaskbar()
         {
+            // 在隐藏/显示任务栏时若系统托盘为打开状态，则将其隐藏（防止在打开系统托盘的情况下隐藏任务栏会导致在隐藏任务栏状态下显示系统托盘会同时使任务栏显示的问题）
+            if (HideTaskbarHelper.GetTaryStatus())
+                HideTaskbarHelper.ChangeTray();
+
             tsm_hideOrShowTaskbar.Checked = !tsm_hideOrShowTaskbar.Checked;
 
             if (tsm_hideOrShowTaskbar.Checked)
@@ -159,10 +163,12 @@ namespace HideTaskbar
         // 隐藏/显示系统托盘
         private void HideOrShowTray()
         {
-            if (HideTaskbarHelper.GetTaryStatus())
-                HideTaskbarHelper.ChangeTray(true);
-            else
-                HideTaskbarHelper.ChangeTray(false);
+            //if (HideTaskbarHelper.GetTaryStatus())
+            //    HideTaskbarHelper.ChangeTray(true);
+            //else
+            //    HideTaskbarHelper.ChangeTray(false);
+
+            HideTaskbarHelper.ChangeTray();
         }
 
         // 设置是否启动后自动隐藏任务栏

--- a/HideTaskbar/Utils/HideTaskbarHelper.cs
+++ b/HideTaskbar/Utils/HideTaskbarHelper.cs
@@ -34,18 +34,69 @@ namespace HideTaskbar.Utils
 
         #region 查找和显示/隐藏 Windows 窗口的 Windows API 函数
         private const int SW_HIDE = 0;
-        private const int SW_SHOW = 1;
+        private const int SW_SHOWNORMAL = 1;
+        private const int SW_SHOWMINIMIZED = 2;
+        private const int SW_SHOWMAXIMIZED = 3;
 
         [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-        private static extern int FindWindow(string className, string windowText);
+        private static extern IntPtr FindWindow(string className, string windowText);
 
-        [DllImport("user32.dll")]
-        private static extern int ShowWindow(int hwnd, int command);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChild, string className, string? windowText);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern int ShowWindow(IntPtr hwnd, int command);
+        #endregion
+
+        #region 非阻塞向指定窗口的消息队列中投递一条消息
+        private const int BM_CLICK = 0x00F5;
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern bool PostMessage(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
         #endregion
 
         #region 判断窗口是否为可见状态的 Windows API 函数
-        [DllImport("user32.dll")]
-        private static extern bool IsWindowVisible(int hWnd);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern bool IsWindowVisible(IntPtr hWnd);
+        #endregion
+
+        #region 获取窗口位置
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+        #endregion
+
+        #region 设置窗口位置
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+        // Enum for SetWindowPos flags
+        [Flags]
+        private enum SetWindowPosFlags : uint
+        {
+            SWP_ASYNCWINDOWPOS = 0x4000,
+            SWP_DEFERERASE = 0x2000,
+            SWP_DRAWFRAME = 0x0020,
+            SWP_FRAMECHANGED = 0x0020,
+            SWP_HIDEWINDOW = 0x0080,
+            SWP_NOACTIVATE = 0x0010,
+            SWP_NOCOPYBITS = 0x0100,
+            SWP_NOMOVE = 0x0002,
+            SWP_NOOWNERZORDER = 0x0200,
+            SWP_NOREDRAW = 0x0008,
+            SWP_NOREPOSITION = 0x0200,
+            SWP_NOSENDCHANGING = 0x0400,
+            SWP_NOSIZE = 0x0001,
+            SWP_NOZORDER = 0x0004,
+            SWP_SHOWWINDOW = 0x0040
+        }
+        #endregion
+
+        #region 设置窗口焦点
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern uint AllowSetForegroundWindow(uint dwProcessId);
         #endregion
 
         /// <summary>
@@ -71,16 +122,16 @@ namespace HideTaskbar.Utils
         /// <param name="status">状态</param>
         public static void ChangeTaskbar(bool status)
         {
-            int hwndPrimary = FindWindow("Shell_TrayWnd", "");
-            ShowWindow(hwndPrimary, status ? SW_HIDE : SW_SHOW);
+            IntPtr hwndPrimary = FindWindow("Shell_TrayWnd", "");
+            ShowWindow(hwndPrimary, status ? SW_HIDE : SW_SHOWNORMAL);
 
             // 隐藏其他显示器上的任务栏
             foreach (var screen in Screen.AllScreens)
             {
                 if (!screen.Primary)
                 {
-                    int hwndSecondary = FindWindow("Shell_SecondaryTrayWnd", "");
-                    ShowWindow(hwndSecondary, status ? SW_HIDE : SW_SHOW);
+                    IntPtr hwndSecondary = FindWindow("Shell_SecondaryTrayWnd", "");
+                    ShowWindow(hwndSecondary, status ? SW_HIDE : SW_SHOWNORMAL);
                 }
             }
         }
@@ -90,18 +141,65 @@ namespace HideTaskbar.Utils
         /// </summary>
         public static Boolean GetTaryStatus()
         {
-            int hwndPrimary = FindWindow("NotifyIconOverflowWindow", "");
+            IntPtr hwndPrimary = FindWindow("NotifyIconOverflowWindow", "");
             return IsWindowVisible(hwndPrimary);
         }
 
+        #region 【已弃用】此方法直接通过系统托盘窗口的句柄来显示，会导致托盘内新增图标时不会自动扩大系统托盘窗口的大小，导致部分图标不可见，以及开机自启动时自动隐藏任务栏，显示系统托盘会失效。
         /// <summary>
         /// 显示/隐藏系统托盘（已使用 WinSpy++ 查看，目前无法操作 Win11 的系统托盘）
         /// </summary>
         /// <param name="status">状态</param>
         public static void ChangeTray(bool status)
         {
-            int hwndPrimary = FindWindow("NotifyIconOverflowWindow", "");
-            ShowWindow(hwndPrimary, status ? SW_HIDE : SW_SHOW);
+            IntPtr hwndPrimary = FindWindow("NotifyIconOverflowWindow", "");
+            ShowWindow(hwndPrimary, status ? SW_HIDE : SW_SHOWNORMAL);
+        }
+        #endregion
+
+        #region 【新方法】使用找到任务栏句柄上的系统托盘按钮句柄上的按钮，再通过向按钮发送点击消息模拟点击系统托盘按钮（解决了系统托盘窗口大小不自动扩大的问题以及开机自启动时自动隐藏任务栏显示系统托盘失效的问题，但出现了新的问题：系统托盘在一些刷新情况下第一次会默认显示在屏幕左上角)
+        /// <summary>
+        /// 显示/隐藏系统托盘（已使用 WinSpy++ 查看，目前无法操作 Win11 的系统托盘）
+        /// </summary>
+        /// <param name="status">状态</param>
+        public static void ChangeTray()
+        {
+            IntPtr hwndPrimary = FindWindow("Shell_TrayWnd", "");
+            IntPtr hwndSecond = FindWindowEx(hwndPrimary, IntPtr.Zero, "TrayNotifyWnd", null);
+            IntPtr buttonHandle = FindWindowEx(hwndSecond, IntPtr.Zero, "Button", null);
+
+            if (buttonHandle != IntPtr.Zero)
+            {
+                // 在此显示任务栏的目的是为了防止无任务栏的情况下通过模拟点击系统托盘按钮打开系统托盘，系统托盘会显示在屏幕的左上角
+                ChangeTaskbar(false);
+                // 向按钮发送点击消息
+                PostMessage(buttonHandle, BM_CLICK, IntPtr.Zero, IntPtr.Zero);
+                // 显示系统托盘后给予其焦点，解决无法通过点击其他位置来隐藏系统托盘的问题
+                IntPtr hwndTray = FindWindow("NotifyIconOverflowWindow", "");
+                FocusExternalWindow(hwndTray);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// 将指定窗口句柄设为焦点
+        /// </summary>
+        /// <param name="handle">需设置焦点的窗口句柄</param>
+        /// <exception cref="Exception">抛出异常</exception>
+        public static void FocusExternalWindow(IntPtr handle)
+        {
+            try
+            {
+                // 允许所有进程设置前台窗口。0xFFFFFFFF表示允许所有进程。
+                // 如果你知道目标窗口所属的具体进程ID，可以传入那个进程ID以增加安全性。
+                AllowSetForegroundWindow(0xFFFFFFFF);
+                // 将目标窗口设置为前台并赋予焦点
+                SetForegroundWindow(handle);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"无法将焦点转移到目标窗口: {ex.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
1. 通过在显示系统托盘的同时将`焦点转移`到系统托盘窗口。
    - 解决了任务栏隐藏的状态下显示系统托盘后，鼠标点击其他位置不会自动隐藏系统托盘的问题

2. 目前研究了一种更好的方法，通过使用找到任务栏句柄上的系统托盘按钮句柄上的按钮，再通过向按钮`发送点击消息`模拟点击系统托盘按钮来打开系统托盘的方法，替代了原来的直接显示/隐藏系统托盘窗口的方式。
    - 解决了任务栏隐藏的状态下显示系统托盘后，系统托盘窗口大小不自动更新的问题
    - 解决了开机自启动时自动隐藏任务栏后，显示系统托盘失效的问题

    > 我猜测通过点击系统托盘按钮的方式展开关闭系统托盘窗口会触发系统托盘的一些系统级的底层逻辑，其中包含了更新窗口大小等，所以解决了上述两个问题，但之前的直接显示系统托盘窗口的方式不会触发。

    > 但此方法带来了一些新的问题：在任务栏隐藏的状态下，通过此方法来显示系统托盘，会导致系统托盘窗口显示在屏幕的左上角（类似系统托盘无法找到任务栏作为锚点来定位）。我通过在向按钮发送点击消息之前将任务栏先显示，再发送点击消息，最后再次隐藏任务栏解决了此问题。（因为执行速度极快，所以肉眼几乎不会察觉到任务栏的回显，但无法完全规避）

    > 然后其实只解决了一部分问题，还有一种情况，就是在系统托盘出现一些更新时的第一次会出现相同的问题，应该也是系统托盘无法找到任务栏作为锚点来定位（比如系统托盘中的某个图标的程序其实已经退出，但图标还未消失，当鼠标放到图标上时，系统托盘会将其更新掉），但此问题无法监听捕获，所以暂时也无法解决（我认为这也属于实在是无法解决的系统级底层问题，所以暂时放弃解决此问题）